### PR TITLE
Improve error handling during identity fetching

### DIFF
--- a/iamzero/__init__.py
+++ b/iamzero/__init__.py
@@ -14,7 +14,7 @@ _INITPID = None
 WARNED_UNINITIALIZED = False
 
 
-def init(token: str = None, url: str = None, debug: bool = None):
+def init(token: str = None, url: str = None, debug: bool = None, quiet: bool = None):
     global _IAMZERO_CLIENT
     global _INITPID
 
@@ -29,7 +29,7 @@ def init(token: str = None, url: str = None, debug: bool = None):
             )
             _IAMZERO_CLIENT.close()
 
-    config = Config(token=token, url=url, debug=debug)
+    config = Config(token=token, url=url, debug=debug, quiet=quiet)
     _IAMZERO_CLIENT = Client(config=config)
     _INITPID = pid
 

--- a/iamzero/config.py
+++ b/iamzero/config.py
@@ -11,6 +11,7 @@ CONFIG_DEFAULT_VALUES = {
     "url": "https://app.iamzero.dev",
     "debug": False,
     "token": None,
+    "quiet": False,
     "max_batch_size": 100,
     "send_frequency": 0.25,
     "user_agent_addition": "",


### PR DESCRIPTION
Should prevent IAM Zero from causing a Python application to hang if
there is an error while fetching the AWS identity.

Also adds a 5s timeout as a failsafe in case the AWS STS request hangs.

Closes #2.