### PR TITLE
Fix client initialisation error in AWS Lambda

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = 0.1.2-dev0
+current_version = 0.1.3-dev0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)-(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}

--- a/iamzero/__init__.py
+++ b/iamzero/__init__.py
@@ -31,7 +31,13 @@ def init(
     global _INITPID
 
     pid = os.getpid()
-    if _IAMZERO_CLIENT:
+
+    # require that the IAM Zero identity fetcher is defined
+    # if it is not defined, the library may not have been fully set up
+    # and we should initialise it again.
+    # This has occurred in AWS Lambda environments, resulting in the error:
+    # `'NoneType' object has no attribute 'fetch_identity'` being thrown upon initialisation.
+    if _IAMZERO_CLIENT and _IAMZERO_CLIENT.identity_fetcher is not None:
         if pid == _INITPID:
             _IAMZERO_CLIENT.log("iamzero is already initialised, skipping init")
             return

--- a/iamzero/version.py
+++ b/iamzero/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.2"
+VERSION = "0.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iamzero"
-version = "0.1.2" 
+version = "0.1.3" 
 description = "iam-zero least-privilege instrumentation client for Python"
 readme = "README.md"
 homepage = "https://iamzero.dev"


### PR DESCRIPTION
In initial testing of the IAM Zero client with Lambda functions, we received the error `'NoneType' object has no attribute 'fetch_identity'` if the function had a warm start.

This is due to the `identity_fetcher` field in Client being set to None when the client is closed. This PR adds an additional check to see if `identity_fetcher` is defined, and if not, reinitialises the IAM Zero client.