### PR TITLE
Guard against the identity fetcher being None

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = 0.1.3-dev0
+current_version = 0.1.4-dev0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)-(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}

--- a/iamzero/__init__.py
+++ b/iamzero/__init__.py
@@ -74,7 +74,7 @@ def send_event(data: Dict):
 
 def fetch_identity(access_key=None, secret_key=None, token=None):
     client = get_client()
-    if client:
+    if client and client.identity_fetcher:
         client.identity_fetcher.fetch_identity(
             access_key=access_key, secret_key=secret_key, token=token
         )

--- a/iamzero/version.py
+++ b/iamzero/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.3"
+VERSION = "0.1.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iamzero"
-version = "0.1.3" 
+version = "0.1.4" 
 description = "iam-zero least-privilege instrumentation client for Python"
 readme = "README.md"
 homepage = "https://iamzero.dev"


### PR DESCRIPTION
If the identity_fetcher is None when we call iamzero.fetch_identity, it causes an exception to be thrown. This PR fixes that by introducing an additional check.